### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ['*']
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: write
@@ -68,7 +68,7 @@ jobs:
   build-flatpak:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
2 changes proposed for the CI workflow.

1. default branch is named `main` for this repo so updated in the workflow.
2. sync flatpak gnome version after PR #28 leaved it untouched for the CI workflow.