### PR TITLE
Add aarch64 flatpak builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,15 @@ jobs:
           path: dist/debian/parla/*.deb
 
   build-flatpak:
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
@@ -75,9 +83,10 @@ jobs:
 
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
+          arch: ${{ matrix.arch }}
           manifest-path: dist/flatpak/io.github.trufae.Parla.json
-          bundle: parla.flatpak
-          cache-key: flatpak-builder-${{ hashFiles('dist/flatpak/io.github.trufae.Parla.json') }}
+          bundle: parla-${{ matrix.arch }}.flatpak
+          cache-key: flatpak-builder-${{ matrix.arch }}-${{ hashFiles('dist/flatpak/io.github.trufae.Parla.json') }}
 
   build-macos:
     runs-on: macos-26

--- a/dist/flatpak/io.github.trufae.Parla.json
+++ b/dist/flatpak/io.github.trufae.Parla.json
@@ -21,8 +21,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://github.com/chatmail/core/releases/download/v2.51.0/deltachat-rpc-server-x86_64-linux",
-                    "sha256": "c943a826ef9668fb4f3f065c239d14275acf60eed6e968e03dd6498a9052cbd4",
+                    "url": "https://github.com/chatmail/core/releases/download/v2.53.0/deltachat-rpc-server-x86_64-linux",
+                    "sha256": "dcc37af7b7e95aae714c2366ff9f6d5c64170d0a7bb72cd7e3926a1a46e7e750",
                     "dest-filename": "deltachat-rpc-server",
                     "only-arches": [
                         "x86_64"
@@ -37,8 +37,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/chatmail/core/releases/download/v2.51.0/deltachat-rpc-server-aarch64-linux",
-                    "sha256": "395577d92a957b80eeace5299dbf3087324de61f5f8d37522f58b3206f329926",
+                    "url": "https://github.com/chatmail/core/releases/download/v2.53.0/deltachat-rpc-server-aarch64-linux",
+                    "sha256": "2df89ca213948e4557a11eff3ffff05efd46c0314374fc791309bd1b7fe6b769",
                     "dest-filename": "deltachat-rpc-server",
                     "only-arches": [
                         "aarch64"


### PR DESCRIPTION
Fixes #34 by adding aarch64 flatpak build.

Additionally it also updates flatpak dependencies.