### PR TITLE
Add build script and ChatSwitcher for chat navigation

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Build script for Parla — a Delta Chat client for GNOME
+set -e
+
+cd "$(dirname "$0")"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    # Homebrew's pkg-config directories are not always present in GUI or
+    # non-login shells, so normalize the build environment on macOS.
+    . ./scripts/macos/env.sh
+    BUILD_DIR="${BUILD_DIR:-builddir-macos}"
+else
+    BUILD_DIR="${BUILD_DIR:-builddir}"
+fi
+
+if [ ! -f "$BUILD_DIR/build.ninja" ]; then
+    if [ -d "$BUILD_DIR" ]; then
+        echo "Removing incomplete build directory: $BUILD_DIR"
+        rm -rf "$BUILD_DIR"
+    fi
+    meson setup "$BUILD_DIR"
+fi
+
+meson compile -C "$BUILD_DIR"
+
+echo ""
+echo "Build successful! Run with:"
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "  make macos-run"
+else
+    echo "  ./$BUILD_DIR/parla"
+fi

--- a/docs/dev/shortcut.md
+++ b/docs/dev/shortcut.md
@@ -1,0 +1,167 @@
+# Keyboard shortcuts (developer guide)
+
+Parla handles keyboard shortcuts centrally in `Window`, with feature-specific
+logic extracted into modules under `src/shortcuts/`. This document describes the
+current layout and how to extend it.
+
+## Entry point
+
+`Window` installs a capture-phase `Gtk.EventControllerKey` in `build_ui()` and
+dispatches keys from `on_window_key_pressed()` in `src/window.vala`.
+
+Order of handling:
+
+1. Image / video viewer overlays (when visible)
+2. Escape (dismiss transient UI, focus compose entry, cancel reply/edit)
+3. Type-ahead (printable keys redirected to the compose entry)
+4. **Shortcut modules** — e.g. `chat_switcher.handle_key()`
+5. Global shortcuts with the platform primary modifier (Ctrl on Linux/Windows,
+   Command on macOS)
+
+Return `true` from a handler to consume the key; `false` lets GTK propagate it.
+
+## Directory layout
+
+```
+src/shortcuts/
+  chat_switcher.vala   # in-conversation chat navigation
+```
+
+New shortcut groups should get their own file here (e.g. `compose.vala`,
+`global.vala`) rather than growing `window.vala` further.
+
+Register new `.vala` files in `meson.build` alongside
+`src/shortcuts/chat_switcher.vala`.
+
+## Application state shortcuts depend on
+
+| State | Where | Used for |
+| --- | --- | --- |
+| Chat open | `Window.current_chat_id`, `Window.current_view()` | Whether in-conversation shortcuts apply |
+| Modal open | `Window.active_modal` | Block shortcuts while a dialog is open; cleared on `dialog.closed` |
+| Visible chat | `content_stack.visible_child_name` | `"chat_<id>"` vs `"empty"` |
+| Focus | `Window.focus_widget` / `get_focus()` | Whether focus is in sidebar, search, dialog, etc. |
+
+`present_modal()` sets `active_modal` and, on close, restores focus to the
+compose entry via `current_view().focus_entry()`.
+
+## `ChatSwitcher` (`src/shortcuts/chat_switcher.vala`)
+
+Handles **in-conversation chat navigation** — moving between chats while
+viewing a conversation, without opening the sidebar.
+
+### Bindings
+
+| Action | Linux / Windows | macOS |
+| --- | --- | --- |
+| Previous chat | `Alt+Up` | `Option+Up` |
+| Next chat | `Alt+Down` | `Option+Down` |
+| Previous chat | `Ctrl+Page Up` | `Command+Page Up` |
+| Next chat | `Ctrl+Page Down` | `Command+Page Down` |
+
+Navigation stops at the first and last chat (no wrap-around).
+
+### When shortcuts apply (`can_switch()`)
+
+Allowed when:
+
+- A chat is open (`current_view() != null`)
+- No modal is open (`active_modal == null`)
+- Focus is not in a blocking widget:
+  - `Adw.Dialog` or `Gtk.Popover`
+  - Any `Gtk.SearchEntry` (sidebar search or in-conversation search)
+  - The sidebar, when `split_view.show_sidebar` is true
+
+Allowed even when focus is on the content header or elsewhere in the content
+pane — e.g. after closing the shortcuts dialog.
+
+### Navigation logic
+
+1. Build an ordered list of visible chat IDs from `chat_listbox`, respecting the
+   sidebar search filter via `Window.shortcuts_filter_chat_row()`.
+2. If the listbox has no visible rows, fall back to `chat_store` order.
+3. Find the current chat index; move by `delta` (`-1` = previous, `+1` = next).
+4. Call `Window.select_chat_by_id()` to switch.
+
+### Construction
+
+`ChatSwitcher` is created at the end of `Window.build_ui()`:
+
+```vala
+chat_switcher = new ChatSwitcher (
+    this, chat_listbox, chat_store, sidebar_box, split_view);
+```
+
+It holds `unowned` references to window widgets passed in at init time.
+
+### Shortcuts dialog
+
+`ChatSwitcher.SHORTCUT_ENTRIES` is a flat `title, accelerator` pair array.
+`append_shortcut_rows()` renders those rows in the keyboard-shortcuts dialog.
+
+`Window.show_keyboard_shortcuts_dialog()` inserts them between two static
+sections:
+
+- `SHORTCUTS_BEFORE_CHAT_SWITCHER`
+- `SHORTCUTS_AFTER_CHAT_SWITCHER`
+
+Other global shortcut labels remain in `window.vala`.
+
+## `Window` helpers for shortcut modules
+
+Shortcut modules in `src/shortcuts/` cannot access `Window` private fields.
+Expose the minimum via `internal` methods on `Window` (visible within the same
+Vala build):
+
+| Method | Purpose |
+| --- | --- |
+| `shortcuts_modal_open()` | Whether a modal dialog is open |
+| `shortcuts_focus_widget()` | Effective keyboard focus |
+| `shortcuts_filter_chat_row()` | Sidebar search filter for chat list rows |
+
+Public `Window` APIs used by shortcut modules today:
+
+- `current_chat_id`, `current_view()`, `select_chat_by_id()`
+
+Prefer adding a small `internal` helper on `Window` over making unrelated
+fields public.
+
+## Adding a new shortcut module
+
+1. Create `src/shortcuts/<name>.vala` with a class in namespace `Dc`.
+2. Add a `handle_key(uint keyval, Gdk.ModifierType state) -> bool` method.
+3. Optionally add `SHORTCUT_ENTRIES` and `append_shortcut_rows()` for the
+   shortcuts dialog.
+4. Store an instance on `Window` (e.g. `private ComposeShortcuts compose_shortcuts`).
+5. Construct it in `build_ui()` once required widgets exist.
+6. Call `handle_key()` from `on_window_key_pressed()` at the appropriate priority.
+7. Add the file to `meson.build`.
+
+### Checklist for in-conversation shortcuts
+
+- [ ] Gate on `current_view() != null`
+- [ ] Respect `shortcuts_modal_open()`
+- [ ] Walk focus ancestors; block sidebar / search / dialogs when needed
+- [ ] Return `true` when the key is consumed (including at list boundaries)
+- [ ] Document bindings in `SHORTCUT_ENTRIES` if user-facing
+
+## Shortcuts still in `window.vala`
+
+These remain in `on_window_key_pressed()` behind
+`Platform.has_primary_modifier()`:
+
+- New chat / group / channel
+- Settings, search in conversation, quick switch
+- Account menu, refresh, sidebar toggle/compact
+- Font size adjust (keys and Ctrl+scroll)
+- Close window, quit
+
+`Ctrl+Tab` / `Ctrl+Shift+Tab` for chat switching were removed intentionally;
+re-add via a shortcut module when needed.
+
+## Platform notes
+
+- Use `<Primary>` in accelerator strings; resolve with
+  `Platform.primary_accelerator_prefix()` for display labels.
+- `Platform.has_primary_modifier()` maps to Ctrl (non-macOS) or Command (macOS).
+- Alt+arrow bindings use `Gdk.ModifierType.ALT_MASK` explicitly (Option on macOS).

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ sources = files(
   'src/platform.c',
   'src/application.vala',
   'src/window.vala',
+  'src/shortcuts/chat_switcher.vala',
   'src/rpc_transport.vala',
   'src/rpc_params.vala',
   'src/rpc_parsers.vala',

--- a/src/shortcuts/chat_switcher.vala
+++ b/src/shortcuts/chat_switcher.vala
@@ -1,0 +1,169 @@
+namespace Dc {
+
+    /**
+     * In-conversation shortcuts for moving between chats:
+     * Alt+Up/Down and Ctrl+Page Up/Down (Command on macOS).
+     */
+    public class ChatSwitcher : Object {
+
+        public const string[] SHORTCUT_ENTRIES = {
+            "Next conversation (in chat)",     "<Alt>Down",
+            "Previous conversation (in chat)", "<Alt>Up",
+            "Next conversation (in chat)",     "<Primary>Page_Down",
+            "Previous conversation (in chat)", "<Primary>Page_Up",
+        };
+
+        private unowned Window window;
+        private unowned Gtk.ListBox chat_listbox;
+        private unowned GLib.ListStore chat_store;
+        private unowned Gtk.Box sidebar_box;
+        private unowned Adw.OverlaySplitView split_view;
+
+        public ChatSwitcher (Window window,
+                             Gtk.ListBox chat_listbox,
+                             GLib.ListStore chat_store,
+                             Gtk.Box sidebar_box,
+                             Adw.OverlaySplitView split_view) {
+            this.window = window;
+            this.chat_listbox = chat_listbox;
+            this.chat_store = chat_store;
+            this.sidebar_box = sidebar_box;
+            this.split_view = split_view;
+        }
+
+        public bool handle_key (uint keyval, Gdk.ModifierType state) {
+            if (!can_switch ()) return false;
+
+            bool alt_arrows = (state & Gdk.ModifierType.ALT_MASK) != 0
+                && (state & (Gdk.ModifierType.CONTROL_MASK
+                             | Gdk.ModifierType.SUPER_MASK
+                             | Gdk.ModifierType.META_MASK)) == 0;
+            bool primary_page = Platform.has_primary_modifier (state)
+                && (state & Gdk.ModifierType.ALT_MASK) == 0;
+
+            if (!alt_arrows && !primary_page) return false;
+
+            if (keyval == Gdk.Key.Up || keyval == Gdk.Key.KP_Up
+                || (primary_page && (keyval == Gdk.Key.Page_Up
+                                     || keyval == Gdk.Key.KP_Page_Up))) {
+                return select_adjacent (-1);
+            }
+            if (keyval == Gdk.Key.Down || keyval == Gdk.Key.KP_Down
+                || (primary_page && (keyval == Gdk.Key.Page_Down
+                                     || keyval == Gdk.Key.KP_Page_Down))) {
+                return select_adjacent (1);
+            }
+            return false;
+        }
+
+        public void append_shortcut_rows (Gtk.ListBox list) {
+            for (int i = 0; i + 1 < SHORTCUT_ENTRIES.length; i += 2) {
+                var row = new Adw.ActionRow ();
+                row.title = SHORTCUT_ENTRIES[i];
+                var lbl = new Gtk.Label (shortcut_label_text (SHORTCUT_ENTRIES[i + 1]));
+                lbl.valign = Gtk.Align.CENTER;
+                lbl.add_css_class ("dim-label");
+                row.add_suffix (lbl);
+                list.append (row);
+            }
+        }
+
+        private bool can_switch () {
+            if (window.current_view () == null) return false;
+            if (window.shortcuts_modal_open ()) return false;
+
+            var focus = window.shortcuts_focus_widget ();
+            if (focus == null) return true;
+
+            for (var w = focus; w != null; w = w.get_parent ()) {
+                if (w is Gtk.Popover || w is Adw.Dialog) return false;
+                if (w is Gtk.SearchEntry) return false;
+                if (w == sidebar_box && split_view.show_sidebar) return false;
+            }
+            return true;
+        }
+
+        private bool select_adjacent (int delta) {
+            int[] visible_ids = {};
+            Gtk.ListBoxRow? row;
+            int idx = 0;
+
+            while ((row = chat_listbox.get_row_at_index (idx)) != null) {
+                if (window.shortcuts_filter_chat_row (row)) {
+                    var chat_row = row.child as ChatRow;
+                    if (chat_row != null) {
+                        visible_ids += chat_row.chat_id;
+                    }
+                }
+                idx++;
+            }
+
+            if (visible_ids.length == 0) {
+                return select_adjacent_from_store (delta);
+            }
+            if (visible_ids.length == 1) return true;
+
+            int current_index = -1;
+            for (int i = 0; i < visible_ids.length; i++) {
+                if (visible_ids[i] == window.current_chat_id) {
+                    current_index = i;
+                    break;
+                }
+            }
+
+            if (current_index < 0) {
+                return window.select_chat_by_id (
+                    visible_ids[delta > 0 ? 0 : visible_ids.length - 1]);
+            }
+            if (delta < 0 && current_index == 0) {
+                return true;
+            }
+            if (delta > 0 && current_index == visible_ids.length - 1) {
+                return true;
+            }
+
+            return window.select_chat_by_id (visible_ids[current_index + delta]);
+        }
+
+        private bool select_adjacent_from_store (int delta) {
+            uint n = chat_store.get_n_items ();
+            if (n == 0) return false;
+            if (n == 1) return true;
+
+            int current_index = -1;
+            for (uint i = 0; i < n; i++) {
+                var entry = (ChatEntry) chat_store.get_item (i);
+                if (entry.id == window.current_chat_id) {
+                    current_index = (int) i;
+                    break;
+                }
+            }
+
+            if (current_index < 0) {
+                var target = (ChatEntry) chat_store.get_item (
+                    delta > 0 ? 0 : n - 1);
+                return window.select_chat_by_id (target.id);
+            }
+            if (delta < 0 && current_index == 0) {
+                return true;
+            }
+            if (delta > 0 && current_index == (int) n - 1) {
+                return true;
+            }
+
+            var next = (ChatEntry) chat_store.get_item ((uint) (current_index + delta));
+            return window.select_chat_by_id (next.id);
+        }
+
+        private static string shortcut_label_text (string accelerator) {
+            uint key;
+            Gdk.ModifierType mods;
+            var resolved = accelerator.replace ("<Primary>",
+                Platform.primary_accelerator_prefix ());
+            if (!Gtk.accelerator_parse (resolved, out key, out mods)) {
+                return resolved;
+            }
+            return Gtk.accelerator_get_label (key, mods);
+        }
+    }
+}

--- a/src/window.vala
+++ b/src/window.vala
@@ -71,6 +71,7 @@ namespace Dc {
         private VideoPlayer video_player;
         private EventHandler events;
         private ChatContextMenu chat_menu;
+        private ChatSwitcher chat_switcher;
         private bool reconnecting_rpc = false;
         private uint unread_notification_timer = 0;
         private int[] pending_unread_notification_accounts = {};
@@ -98,7 +99,13 @@ namespace Dc {
 
         private void present_modal (Adw.Dialog dialog) {
             active_modal = dialog;
-            dialog.closed.connect (() => { active_modal = null; });
+            dialog.closed.connect (() => {
+                active_modal = null;
+                /* Return focus to the compose entry so in-conversation
+                   shortcuts work immediately after dismissing a modal. */
+                var v = current_view ();
+                if (v != null) v.focus_entry ();
+            });
             dialog.present (this);
         }
 
@@ -465,6 +472,9 @@ namespace Dc {
             });
 
             apply_sidebar_mode (true);
+
+            chat_switcher = new ChatSwitcher (
+                this, chat_listbox, chat_store, sidebar_box, split_view);
 
             /* Fullscreen image viewer overlay */
             var image_overlay = new Gtk.Overlay ();
@@ -2108,6 +2118,8 @@ namespace Dc {
                 }
             }
 
+            if (chat_switcher.handle_key (keyval, state)) return true;
+
             /* All other shortcuts require the platform primary modifier:
                Ctrl normally, Command on macOS. */
             if (!Platform.has_primary_modifier (state)) return false;
@@ -2119,12 +2131,6 @@ namespace Dc {
 #endif
 
             switch (lower_key) {
-            case Gdk.Key.Tab:
-            case Gdk.Key.ISO_Left_Tab:
-            case Gdk.Key.KP_Tab:
-                return select_adjacent_chat (
-                    ((state & Gdk.ModifierType.SHIFT_MASK) != 0 ||
-                     keyval == Gdk.Key.ISO_Left_Tab) ? -1 : 1);
             case Gdk.Key.a:
                 if ((state & Gdk.ModifierType.SHIFT_MASK) == 0) return false;
                 show_account_menu ();
@@ -2245,6 +2251,18 @@ namespace Dc {
             return false;
         }
 
+        internal bool shortcuts_modal_open () {
+            return active_modal != null;
+        }
+
+        internal Gtk.Widget? shortcuts_focus_widget () {
+            return focus_widget ?? get_focus ();
+        }
+
+        internal bool shortcuts_filter_chat_row (Gtk.ListBoxRow row) {
+            return filter_chats (row);
+        }
+
 #if PARLA_MACOS_CLIPBOARD_WORKAROUND
         private bool paste_macos_text_into_focus () {
             if (!Platform.is_macos ()) return false;
@@ -2311,43 +2329,6 @@ namespace Dc {
             account_menu_button.popup ();
         }
 
-        private bool select_adjacent_chat (int delta) {
-            int row_count = 0;
-            int current_index = -1;
-            Gtk.ListBoxRow? row;
-
-            while ((row = chat_listbox.get_row_at_index (row_count)) != null) {
-                var chat_row = row.child as ChatRow;
-                if (chat_row != null && chat_row.chat_id == current_chat_id) {
-                    current_index = row_count;
-                }
-                row_count++;
-            }
-
-            if (row_count == 0) return false;
-            if (row_count == 1) return true;
-
-            int target_index;
-            if (current_index < 0) {
-                target_index = delta > 0 ? 0 : row_count - 1;
-            } else {
-                target_index = current_index + delta;
-                if (target_index < 0) {
-                    target_index = row_count - 1;
-                } else if (target_index >= row_count) {
-                    target_index = 0;
-                }
-            }
-
-            row = chat_listbox.get_row_at_index (target_index);
-            if (row == null) return false;
-
-            var chat_row = row.child as ChatRow;
-            if (chat_row == null) return false;
-
-            return select_chat_by_id (chat_row.chat_id);
-        }
-
         private void show_quick_switch_dialog () {
             if (!can_show_account_modal ()) return;
             if (chat_store.get_n_items () == 0) return;
@@ -2375,7 +2356,7 @@ namespace Dc {
             return false;
         }
 
-        private const string[] SHORTCUTS = {
+        private const string[] SHORTCUTS_BEFORE_CHAT_SWITCHER = {
             "New chat",              "<Primary>n",
             "New group",             "<Primary>g",
             "New channel",           "<Primary><Shift>g",
@@ -2386,8 +2367,9 @@ namespace Dc {
             "Search in conversation","<Primary>f",
             "Quick switch chat",     "<Primary>k",
             "Account menu",          "<Primary><Shift>a",
-            "Next conversation",     "<Primary>Tab",
-            "Previous conversation", "<Primary><Shift>Tab",
+        };
+
+        private const string[] SHORTCUTS_AFTER_CHAT_SWITCHER = {
             "Refresh messages",      "<Primary>r",
             "Toggle sidebar",        "<Primary>s",
             "Compact sidebar",       "<Primary><Shift>s",
@@ -2397,15 +2379,23 @@ namespace Dc {
             "Quit application",      "<Primary>q",
         };
 
-        private static string shortcut_accelerator (string accelerator) {
-            return accelerator.replace ("<Primary>",
-                Platform.primary_accelerator_prefix ());
+        private void append_shortcut_rows (Gtk.ListBox list, string[] pairs) {
+            for (int i = 0; i + 1 < pairs.length; i += 2) {
+                var row = new Adw.ActionRow ();
+                row.title = pairs[i];
+                var lbl = new Gtk.Label (shortcut_label_text (pairs[i + 1]));
+                lbl.valign = Gtk.Align.CENTER;
+                lbl.add_css_class ("dim-label");
+                row.add_suffix (lbl);
+                list.append (row);
+            }
         }
 
         private static string shortcut_label_text (string accelerator) {
             uint key;
             Gdk.ModifierType mods;
-            var resolved = shortcut_accelerator (accelerator);
+            var resolved = accelerator.replace ("<Primary>",
+                Platform.primary_accelerator_prefix ());
             if (!Gtk.accelerator_parse (resolved, out key, out mods)) {
                 return resolved;
             }
@@ -2434,15 +2424,9 @@ namespace Dc {
             list.add_css_class ("boxed-list");
             list.margin_start = list.margin_end = list.margin_top = list.margin_bottom = 12;
 
-            for (int i = 0; i + 1 < SHORTCUTS.length; i += 2) {
-                var row = new Adw.ActionRow ();
-                row.title = SHORTCUTS[i];
-                var lbl = new Gtk.Label (shortcut_label_text (SHORTCUTS[i + 1]));
-                lbl.valign = Gtk.Align.CENTER;
-                lbl.add_css_class ("dim-label");
-                row.add_suffix (lbl);
-                list.append (row);
-            }
+            append_shortcut_rows (list, SHORTCUTS_BEFORE_CHAT_SWITCHER);
+            chat_switcher.append_shortcut_rows (list);
+            append_shortcut_rows (list, SHORTCUTS_AFTER_CHAT_SWITCHER);
 
             var wheel_row = new Adw.ActionRow ();
             wheel_row.title = "Change font size";


### PR DESCRIPTION
implemented https://github.com/trufae/parla/issues/39 for chat change shortcut with `alt + down/up` or `ctl + page-down/page-up` 


<img width="914" height="632" alt="image" src="https://github.com/user-attachments/assets/51160137-aff4-4811-a5c4-bc73b7b7424f" />


also moving from the flat structure to with [src/shortcuts/chat_switcher.vala](https://github.com/trufae/parla/compare/trufae:main...omidz4t:chat-navigation-short-key?expand=1#diff-a3bf91bbf284ee773a911f4c068032564e22a6d674a7f4dcb386d28ad895e624) .