### PR TITLE
macos: keep the app in the Dock when the window is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Want to build it yourself? See [Build](#build) below.
 - Choose whether Markdown is rendered, stripped, or shown as-is.
 - Toggle Shift+Enter vs Enter to send.
 - Toggle desktop notifications for incoming messages when the window is unfocused.
-- Choose bubble, compact IRC, or workspace message layouts, and configure the tray icon for background use.
+- Choose bubble, compact IRC, or workspace message layouts, and configure the tray icon for background use. On macOS, a "Keep in Dock" option keeps Parla running with its Dock icon when the window is closed, with or without the menu bar icon.
 - Choose the JSON-RPC server source: Parla/system auto-discovery or a custom binary.
 
 ### Keyboard shortcuts

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Want to build it yourself? See [Build](#build) below.
 - Choose whether Markdown is rendered, stripped, or shown as-is.
 - Toggle Shift+Enter vs Enter to send.
 - Toggle desktop notifications for incoming messages when the window is unfocused.
-- Choose bubble, compact IRC, or workspace message layouts, and configure the tray icon for background use. On macOS, a "Keep in Dock" option keeps Parla running with its Dock icon when the window is closed, with or without the menu bar icon.
+- Choose bubble, compact IRC, or workspace message layouts, and configure the tray icon for background use. On macOS, closing the window keeps Parla running with its Dock icon always visible, with or without the menu bar icon.
 - Choose the JSON-RPC server source: Parla/system auto-discovery or a custom binary.
 
 ### Keyboard shortcuts

--- a/src/settings_dialog.vala
+++ b/src/settings_dialog.vala
@@ -78,7 +78,6 @@ namespace Dc {
         public bool notifications_enabled { get; set; default = true; }
         public bool show_notification_contents { get; set; default = true; }
         public bool minimize_to_tray { get; set; default = false; }
-        public bool keep_in_dock { get; set; default = false; }
         public bool system_audio_player { get; set; default = false; }
         public bool animate_stickers { get; set; default = true; }
         /* Only honored in builds with -Dwebxdc=true (Webxdc.AVAILABLE). */
@@ -186,7 +185,6 @@ namespace Dc {
             show_notification_contents =
                 kf_bool (kf, "show_notification_contents", true);
             minimize_to_tray = kf_bool (kf, "minimize_to_tray", false);
-            keep_in_dock = kf_bool (kf, "keep_in_dock", false);
             system_audio_player = kf_bool (kf, "system_audio_player", false);
             AudioPlayer.prefer_system = system_audio_player;
             animate_stickers = kf_bool (kf, "animate_stickers", true);
@@ -312,11 +310,6 @@ namespace Dc {
         public void save_minimize_to_tray (bool v) {
             minimize_to_tray = v;
             save_bool ("minimize_to_tray", v);
-        }
-
-        public void save_keep_in_dock (bool v) {
-            keep_in_dock = v;
-            save_bool ("keep_in_dock", v);
         }
 
         public void save_system_audio_player (bool v) {
@@ -818,7 +811,8 @@ namespace Dc {
                     : "Minimize to status bar",
                 Platform.is_macos ()
                     ? "Closing the window keeps Parla running as a menu bar "
-                    + "icon, out of the Dock; notifications still appear"
+                    + "icon; the Dock icon stays visible and notifications "
+                    + "still appear"
                     : "Closing the window keeps Parla running in the status "
                     + "bar; notifications still appear");
             var tray_switch = row_switch (
@@ -828,21 +822,6 @@ namespace Dc {
             });
 
             behavior_group.add (tray_row);
-
-            /* macOS: keep running with the Dock icon when the window is
-               closed, independent of the menu-bar icon. */
-            if (Platform.is_macos ()) {
-                var dock_row = action_row (
-                    "Keep in Dock",
-                    "Closing the window keeps Parla running with its Dock "
-                    + "icon, with or without the menu bar icon");
-                var dock_switch = row_switch (
-                    dock_row, app_window.settings.keep_in_dock);
-                dock_switch.notify["active"].connect (() => {
-                    app_window.set_keep_in_dock (dock_switch.active);
-                });
-                behavior_group.add (dock_row);
-            }
 
             var notifications_group = settings_group (general_page, "Notifications");
             var notif_row = action_row (

--- a/src/settings_dialog.vala
+++ b/src/settings_dialog.vala
@@ -78,6 +78,7 @@ namespace Dc {
         public bool notifications_enabled { get; set; default = true; }
         public bool show_notification_contents { get; set; default = true; }
         public bool minimize_to_tray { get; set; default = false; }
+        public bool keep_in_dock { get; set; default = false; }
         public bool system_audio_player { get; set; default = false; }
         public bool animate_stickers { get; set; default = true; }
         /* Only honored in builds with -Dwebxdc=true (Webxdc.AVAILABLE). */
@@ -185,6 +186,7 @@ namespace Dc {
             show_notification_contents =
                 kf_bool (kf, "show_notification_contents", true);
             minimize_to_tray = kf_bool (kf, "minimize_to_tray", false);
+            keep_in_dock = kf_bool (kf, "keep_in_dock", false);
             system_audio_player = kf_bool (kf, "system_audio_player", false);
             AudioPlayer.prefer_system = system_audio_player;
             animate_stickers = kf_bool (kf, "animate_stickers", true);
@@ -310,6 +312,11 @@ namespace Dc {
         public void save_minimize_to_tray (bool v) {
             minimize_to_tray = v;
             save_bool ("minimize_to_tray", v);
+        }
+
+        public void save_keep_in_dock (bool v) {
+            keep_in_dock = v;
+            save_bool ("keep_in_dock", v);
         }
 
         public void save_system_audio_player (bool v) {
@@ -821,6 +828,21 @@ namespace Dc {
             });
 
             behavior_group.add (tray_row);
+
+            /* macOS: keep running with the Dock icon when the window is
+               closed, independent of the menu-bar icon. */
+            if (Platform.is_macos ()) {
+                var dock_row = action_row (
+                    "Keep in Dock",
+                    "Closing the window keeps Parla running with its Dock "
+                    + "icon, with or without the menu bar icon");
+                var dock_switch = row_switch (
+                    dock_row, app_window.settings.keep_in_dock);
+                dock_switch.notify["active"].connect (() => {
+                    app_window.set_keep_in_dock (dock_switch.active);
+                });
+                behavior_group.add (dock_row);
+            }
 
             var notifications_group = settings_group (general_page, "Notifications");
             var notif_row = action_row (

--- a/src/tray_macos.h
+++ b/src/tray_macos.h
@@ -29,9 +29,3 @@ void parla_macos_tray_hide (void);
 /* Keep the menu labels/checkmark in sync with the app state. */
 void parla_macos_tray_set_window_visible (gboolean visible);
 void parla_macos_tray_set_notifications_enabled (gboolean enabled);
-
-/* While hidden in the tray the app also leaves the Dock and the Cmd-Tab
- * switcher (accessory activation policy) — the GNOME behaviour, where a
- * closed window exists only as the tray icon. Un-hiding restores the
- * Dock icon and re-activates the app. */
-void parla_macos_tray_set_app_hidden (gboolean hidden);

--- a/src/tray_macos.m
+++ b/src/tray_macos.m
@@ -305,31 +305,4 @@ parla_macos_tray_set_notifications_enabled (gboolean enabled)
 		                               : NSControlStateValueOff];
 }
 
-static gboolean
-idle_activate_app (gpointer data)
-{
-	[[NSRunningApplication currentApplication]
-		activateWithOptions:(NSApplicationActivationOptions)(1 << 1)];
-	return G_SOURCE_REMOVE;
-}
-
-void
-parla_macos_tray_set_app_hidden (gboolean hidden)
-{
-	NSApplicationActivationPolicy policy = hidden
-		? NSApplicationActivationPolicyAccessory
-		: NSApplicationActivationPolicyRegular;
-	if ([NSApp activationPolicy] == policy) {
-		return;
-	}
-	[NSApp setActivationPolicy:policy];
-	if (!hidden) {
-		/* Deferred one main-loop turn: right after the policy flip
-		   AppKit has not finished re-registering the app, and an
-		   immediate activation can leave the menu bar on the
-		   previous app. */
-		g_idle_add (idle_activate_app, NULL);
-	}
-}
-
 #endif

--- a/src/tray_macos.vala
+++ b/src/tray_macos.vala
@@ -37,9 +37,6 @@ namespace Dc {
         [CCode (cheader_filename = "tray_macos.h",
                 cname = "parla_macos_tray_set_notifications_enabled")]
         private static extern void tray_set_notifications_enabled (bool enabled);
-        [CCode (cheader_filename = "tray_macos.h",
-                cname = "parla_macos_tray_set_app_hidden")]
-        private static extern void tray_set_app_hidden (bool hidden);
 
         public signal void show_on_current_desktop_requested (
             string? activation_token);
@@ -97,13 +94,6 @@ namespace Dc {
 
         public void set_notifications_enabled (bool enabled) {
             tray_set_notifications_enabled (enabled);
-        }
-
-        /* Hidden-in-tray means gone from the Dock and Cmd-Tab too; see
-           tray_macos.h. Static so window.vala can restore the Dock icon
-           on early present () paths even before any tray exists. */
-        public static void set_app_hidden (bool hidden) {
-            tray_set_app_hidden (hidden);
         }
     }
 }

--- a/src/window.vala
+++ b/src/window.vala
@@ -264,6 +264,7 @@ namespace Dc {
             /* The tray icon stays up the whole time "minimize to status bar"
                is on (like Discord/Telegram), not just while minimized. */
             settings.notify["minimize-to-tray"].connect (sync_tray);
+            settings.notify["keep-in-dock"].connect (sync_tray);
 
             /* Keep the tray menu's show/minimize label matching the window. */
             this.notify["visible"].connect (() => {
@@ -309,6 +310,10 @@ namespace Dc {
         private bool on_close_request () {
             if (quit_requested) return false;
 
+            if (macos_keep_in_dock_enabled ()) {
+                minimize_to_dock ();
+                return true;
+            }
             if (ensure_tray_visible ()) {
                 minimize_to_tray ();
                 return true;
@@ -334,6 +339,11 @@ namespace Dc {
             sync_tray ();
         }
 
+        public void set_keep_in_dock (bool enabled) {
+            settings.save_keep_in_dock (enabled);
+            sync_tray ();
+        }
+
         public void quit_application () { handle_primary_q (); }
 
         public void handle_primary_q () {
@@ -347,6 +357,10 @@ namespace Dc {
         }
 
         public void handle_primary_w () {
+            if (macos_keep_in_dock_enabled ()) {
+                minimize_to_dock ();
+                return;
+            }
             if (ensure_tray_visible () || runs_in_background ()) {
                 minimize_to_tray ();
                 return;
@@ -366,12 +380,20 @@ namespace Dc {
         /* Single source of truth for the tray icon: create it on first need,
            then show/hide it to track the setting. */
         private void sync_tray () {
+            /* keep-in-Dock mode still needs the macOS reopen handler so a
+               Dock click can restore the hidden window, even though no
+               menu-bar item is shown. */
+            if (macos_keep_in_dock_enabled ()) ensure_tray_backend ();
+
             if (!settings.minimize_to_tray) {
                 if (tray != null) tray.hide ();
                 /* In background/service mode the hidden window is
                    deliberate — the tray setting being off (or getting
                    toggled off) must not summon it. */
                 if (runs_in_background ()) return;
+                /* Same for keep-in-Dock: the window is intentionally
+                   hidden, so the setting flipping off must not re-show it. */
+                if (macos_keep_in_dock_enabled () && !this.visible) return;
                 if (held_in_background || !this.visible) restore_from_tray ();
                 else release_background_hold ();
                 return;
@@ -380,28 +402,35 @@ namespace Dc {
             ensure_tray_visible ();
         }
 
+        /* Create the tray backend and wire its callbacks, without showing
+           the status item. macOS needs this even when only keep-in-Dock is
+           enabled: constructing MacosTray installs the reopen handler that
+           brings the hidden window back. */
+        private void ensure_tray_backend () {
+            if (tray != null) return;
+#if MACOS
+            tray = new MacosTray ();
+#else
+            var conn = this.application.get_dbus_connection ();
+            if (conn == null) return;
+            tray = new TrayIcon (conn);
+#endif
+            tray.show_on_current_desktop_requested.connect (
+                show_from_tray_on_current_desktop);
+            tray.window_toggle_requested.connect (
+                toggle_window_from_tray);
+            tray.quit_requested.connect (() => {
+                handle_primary_q ();
+            });
+            tray.notifications_toggle_requested.connect ((enabled) => {
+                set_notifications_enabled (enabled);
+            });
+        }
+
         private bool ensure_tray_visible () {
             if (!settings.minimize_to_tray) return false;
 
-            if (tray == null) {
-#if MACOS
-                tray = new MacosTray ();
-#else
-                var conn = this.application.get_dbus_connection ();
-                if (conn == null) return false;
-                tray = new TrayIcon (conn);
-#endif
-                tray.show_on_current_desktop_requested.connect (
-                    show_from_tray_on_current_desktop);
-                tray.window_toggle_requested.connect (
-                    toggle_window_from_tray);
-                tray.quit_requested.connect (() => {
-                    handle_primary_q ();
-                });
-                tray.notifications_toggle_requested.connect ((enabled) => {
-                    set_notifications_enabled (enabled);
-                });
-            }
+            ensure_tray_backend ();
             if (tray == null) return false;
             tray.set_notifications_enabled (settings.notifications_enabled);
             tray.set_window_visible (this.visible);
@@ -416,6 +445,26 @@ namespace Dc {
                 this.application.hold ();
                 held_in_background = true;
             }
+        }
+
+        /* macOS keep-in-Dock mode: hide the window but stay a regular
+           activation-policy app so the Dock icon (and Cmd-Tab) survive. */
+        private void minimize_to_dock () {
+            close_active_modal ();
+            this.set_visible (false);
+            set_macos_app_hidden (false);
+            if (!held_in_background) {
+                this.application.hold ();
+                held_in_background = true;
+            }
+        }
+
+        private bool macos_keep_in_dock_enabled () {
+#if MACOS
+            return settings.keep_in_dock;
+#else
+            return false;
+#endif
         }
 
         /* On macOS "in the tray" also means out of the Dock and Cmd-Tab

--- a/src/window.vala
+++ b/src/window.vala
@@ -264,7 +264,6 @@ namespace Dc {
             /* The tray icon stays up the whole time "minimize to status bar"
                is on (like Discord/Telegram), not just while minimized. */
             settings.notify["minimize-to-tray"].connect (sync_tray);
-            settings.notify["keep-in-dock"].connect (sync_tray);
 
             /* Keep the tray menu's show/minimize label matching the window. */
             this.notify["visible"].connect (() => {
@@ -310,10 +309,13 @@ namespace Dc {
         private bool on_close_request () {
             if (quit_requested) return false;
 
-            if (macos_keep_in_dock_enabled ()) {
-                minimize_to_dock ();
-                return true;
-            }
+#if MACOS
+            /* Closing the window keeps Parla running with its Dock icon
+               always visible; only an explicit quit (Cmd+Q, the tray menu,
+               Dock > Quit) exits for real. */
+            minimize_to_tray ();
+            return true;
+#else
             if (ensure_tray_visible ()) {
                 minimize_to_tray ();
                 return true;
@@ -327,6 +329,7 @@ namespace Dc {
             }
             release_background_hold ();
             return false;
+#endif
         }
 
         private bool runs_in_background () {
@@ -336,11 +339,6 @@ namespace Dc {
 
         public void set_minimize_to_tray (bool enabled) {
             settings.save_minimize_to_tray (enabled);
-            sync_tray ();
-        }
-
-        public void set_keep_in_dock (bool enabled) {
-            settings.save_keep_in_dock (enabled);
             sync_tray ();
         }
 
@@ -357,15 +355,16 @@ namespace Dc {
         }
 
         public void handle_primary_w () {
-            if (macos_keep_in_dock_enabled ()) {
-                minimize_to_dock ();
-                return;
-            }
+#if MACOS
+            minimize_to_tray ();
+            return;
+#else
             if (ensure_tray_visible () || runs_in_background ()) {
                 minimize_to_tray ();
                 return;
             }
             handle_primary_q ();
+#endif
         }
 
         private void handle_native_file_drop (string path) {
@@ -380,10 +379,12 @@ namespace Dc {
         /* Single source of truth for the tray icon: create it on first need,
            then show/hide it to track the setting. */
         private void sync_tray () {
-            /* keep-in-Dock mode still needs the macOS reopen handler so a
-               Dock click can restore the hidden window, even though no
-               menu-bar item is shown. */
-            if (macos_keep_in_dock_enabled ()) ensure_tray_backend ();
+#if MACOS
+            /* macOS keeps the reopen handler installed so a Dock click
+               brings the hidden window back, even when no menu-bar icon
+               is shown. */
+            ensure_tray_backend ();
+#endif
 
             if (!settings.minimize_to_tray) {
                 if (tray != null) tray.hide ();
@@ -391,9 +392,6 @@ namespace Dc {
                    deliberate — the tray setting being off (or getting
                    toggled off) must not summon it. */
                 if (runs_in_background ()) return;
-                /* Same for keep-in-Dock: the window is intentionally
-                   hidden, so the setting flipping off must not re-show it. */
-                if (macos_keep_in_dock_enabled () && !this.visible) return;
                 if (held_in_background || !this.visible) restore_from_tray ();
                 else release_background_hold ();
                 return;
@@ -403,9 +401,9 @@ namespace Dc {
         }
 
         /* Create the tray backend and wire its callbacks, without showing
-           the status item. macOS needs this even when only keep-in-Dock is
-           enabled: constructing MacosTray installs the reopen handler that
-           brings the hidden window back. */
+           the status item. macOS needs this even when only the Dock icon
+           keeps the app alive: constructing MacosTray installs the reopen
+           handler that brings the hidden window back. */
         private void ensure_tray_backend () {
             if (tray != null) return;
 #if MACOS
@@ -440,40 +438,10 @@ namespace Dc {
         private void minimize_to_tray () {
             close_active_modal ();
             this.set_visible (false);
-            set_macos_app_hidden (true);
             if (!held_in_background) {
                 this.application.hold ();
                 held_in_background = true;
             }
-        }
-
-        /* macOS keep-in-Dock mode: hide the window but stay a regular
-           activation-policy app so the Dock icon (and Cmd-Tab) survive. */
-        private void minimize_to_dock () {
-            close_active_modal ();
-            this.set_visible (false);
-            set_macos_app_hidden (false);
-            if (!held_in_background) {
-                this.application.hold ();
-                held_in_background = true;
-            }
-        }
-
-        private bool macos_keep_in_dock_enabled () {
-#if MACOS
-            return settings.keep_in_dock;
-#else
-            return false;
-#endif
-        }
-
-        /* On macOS "in the tray" also means out of the Dock and Cmd-Tab
-           (see tray_macos.h); a no-op everywhere else. Restoring must run
-           before present () so the window can take focus again. */
-        private static void set_macos_app_hidden (bool hidden) {
-#if MACOS
-            MacosTray.set_app_hidden (hidden);
-#endif
         }
 
         private void close_active_modal () {
@@ -484,7 +452,6 @@ namespace Dc {
         }
 
         public void restore_from_tray () {
-            set_macos_app_hidden (false);
             release_background_hold ();
             this.present ();
         }
@@ -501,7 +468,6 @@ namespace Dc {
 
         private void show_from_tray_on_current_desktop (
                 string? activation_token) {
-            set_macos_app_hidden (false);
             release_background_hold ();
             if (activation_token != null && activation_token.length > 0 &&
                 request_activation_on_current_desktop (activation_token)) {


### PR DESCRIPTION
On macOS, closing the window with the red button or Cmd+W used to quit Parla, and enabling "Minimize to menu bar" also removed the Dock icon. This PR makes the Dock icon **always visible**: closing the window keeps Parla running in the Dock (with or without the menu bar icon), and a Dock click restores the window. Only an explicit quit (Cmd+Q, the tray menu, or Dock > Quit) exits the app.

### What changed

- Closing the window (red button / Cmd+W) no longer quits on macOS; it hides the window while the app keeps running with its Dock icon visible.
- The macOS reopen handler is now installed regardless of the tray setting, so a Dock click always brings the hidden window back.
- Dropped the `keep_in_dock` setting (introduced mid-PR and made redundant by the always-on behavior) and its settings row.
- Removed the now-dead accessory activation-policy shim (`parla_macos_tray_set_app_hidden` / `idle_activate_app` / `MacosTray.set_app_hidden`).
- Updated the "Minimize to menu bar" subtitle and the README to reflect that the Dock icon stays visible.

Behavior on other platforms is unchanged.