### PR TITLE
macos: make the hidden window reopen instantly from the Dock

### DIFF
--- a/src/tray_macos.m
+++ b/src/tray_macos.m
@@ -41,6 +41,15 @@ static struct {
 } tray;
 
 static gboolean
+idle_window_show (gpointer data)
+{
+	if (tray.window_show != NULL) {
+		tray.window_show (tray.user_data);
+	}
+	return G_SOURCE_REMOVE;
+}
+
+static gboolean
 idle_window_toggle (gpointer data)
 {
 	if (tray.window_toggle != NULL) {
@@ -71,7 +80,14 @@ idle_notifications_toggle (gpointer data)
 
 - (void)toggleWindow:(id)sender
 {
-	g_idle_add (idle_window_toggle, NULL);
+	/* Dispatch on the flag captured at click time: "Show Parla" is queued
+	 * as a show, not a toggle, so a Dock click that shows the window
+	 * before this idle runs cannot turn into an unexpected hide. */
+	if (tray.window_visible) {
+		g_idle_add (idle_window_toggle, NULL);
+	} else {
+		g_idle_add (idle_window_show, NULL);
+	}
 }
 
 - (void)toggleNotifications:(id)sender
@@ -118,12 +134,11 @@ parla_tray_call_super_reopen (id self, SEL selector, NSApplication *app,
 	                                           has_visible);
 }
 
-/* Show the window synchronously from the AppKit callback. While the window
- * is hidden the GLib main loop does not wake up promptly to dispatch a
- * queued idle (up to ~12s), so deferring through g_idle_add is not fast
- * enough for a Dock click. The reopen/did-become-active callbacks run on
- * the main thread during ordinary AppKit event processing, where touching
- * GTK is safe. */
+/* Show the window synchronously from the AppKit reopen callback. While the
+ * window is hidden the GLib main loop does not wake up promptly to dispatch
+ * a queued idle (up to ~12s), so deferring through g_idle_add is not fast
+ * enough for a Dock click. The callback runs on the main thread during
+ * ordinary AppKit event processing, where touching GTK is safe. */
 static void
 parla_tray_show_window_now (void)
 {
@@ -131,10 +146,9 @@ parla_tray_show_window_now (void)
 		return;
 	}
 
-	/* Reopen and did-become-active both fire for one Dock click; show only
-	 * once. GTK's visible notify will sync the flag back once the window is
-	 * really on screen. */
-	tray.window_visible = YES;
+	/* The setter keeps the tray menu title in sync with the flag; GTK's
+	 * visible notify re-syncs both once the window is really on screen. */
+	parla_macos_tray_set_window_visible (TRUE);
 
 	if (tray.window_show != NULL) {
 		tray.window_show (tray.user_data);
@@ -150,27 +164,6 @@ parla_tray_should_handle_reopen (id self, SEL selector, NSApplication *app,
 		return NO;
 	}
 	return parla_tray_call_super_reopen (self, selector, app, has_visible);
-}
-
-static void
-parla_tray_did_become_active (id self, SEL selector, NSNotification *notification)
-{
-	Class superclass = class_getSuperclass (object_getClass (self));
-	if (superclass != Nil &&
-	    class_getInstanceMethod (superclass, selector) != NULL) {
-		struct objc_super super_info = {
-			.receiver = self,
-			.super_class = superclass,
-		};
-		typedef void (*MsgSendSuper)(struct objc_super *, SEL, NSNotification *);
-		((MsgSendSuper) objc_msgSendSuper) (
-			&super_info, selector, notification);
-	}
-
-	/* The first Dock click activates the app before AppKit delivers the
-	 * reopen callback. Restore after activation so GTK cannot immediately
-	 * order the intentionally hidden window out again. */
-	parla_tray_show_window_now ();
 }
 
 static void
@@ -196,9 +189,6 @@ parla_tray_install_reopen_handler (void)
 		class_addMethod (subclass,
 		                 @selector (applicationShouldHandleReopen:hasVisibleWindows:),
 		                 (IMP) parla_tray_should_handle_reopen, "c@:@c");
-		class_addMethod (subclass,
-		                 @selector (applicationDidBecomeActive:),
-		                 (IMP) parla_tray_did_become_active, "v@:@");
 		objc_registerClassPair (subclass);
 	}
 

--- a/src/tray_macos.m
+++ b/src/tray_macos.m
@@ -50,15 +50,6 @@ idle_window_toggle (gpointer data)
 }
 
 static gboolean
-idle_window_show (gpointer data)
-{
-	if (tray.window_show != NULL) {
-		tray.window_show (tray.user_data);
-	}
-	return G_SOURCE_REMOVE;
-}
-
-static gboolean
 idle_quit (gpointer data)
 {
 	if (tray.quit != NULL) {
@@ -127,15 +118,59 @@ parla_tray_call_super_reopen (id self, SEL selector, NSApplication *app,
 	                                           has_visible);
 }
 
+/* Show the window synchronously from the AppKit callback. While the window
+ * is hidden the GLib main loop does not wake up promptly to dispatch a
+ * queued idle (up to ~12s), so deferring through g_idle_add is not fast
+ * enough for a Dock click. The reopen/did-become-active callbacks run on
+ * the main thread during ordinary AppKit event processing, where touching
+ * GTK is safe. */
+static void
+parla_tray_show_window_now (void)
+{
+	if (tray.window_visible) {
+		return;
+	}
+
+	/* Reopen and did-become-active both fire for one Dock click; show only
+	 * once. GTK's visible notify will sync the flag back once the window is
+	 * really on screen. */
+	tray.window_visible = YES;
+
+	if (tray.window_show != NULL) {
+		tray.window_show (tray.user_data);
+	}
+}
+
 static BOOL
 parla_tray_should_handle_reopen (id self, SEL selector, NSApplication *app,
                                  BOOL has_visible)
 {
 	if (!tray.window_visible) {
-		g_idle_add (idle_window_show, NULL);
+		parla_tray_show_window_now ();
 		return NO;
 	}
 	return parla_tray_call_super_reopen (self, selector, app, has_visible);
+}
+
+static void
+parla_tray_did_become_active (id self, SEL selector, NSNotification *notification)
+{
+	Class superclass = class_getSuperclass (object_getClass (self));
+	if (superclass != Nil &&
+	    class_getInstanceMethod (superclass, selector) != NULL) {
+		struct objc_super super_info = {
+			.receiver = self,
+			.super_class = superclass,
+		};
+		typedef void (*MsgSendSuper)(struct objc_super *, SEL, NSNotification *);
+		((MsgSendSuper) objc_msgSendSuper) (
+			&super_info, selector, notification);
+	}
+
+	/* The first Dock click activates the app before AppKit delivers the
+	 * reopen callback. Restore after activation so GTK cannot immediately
+	 * order the intentionally hidden window out again. */
+	parla_tray_show_window_now ();
 }
 
 static void
@@ -161,6 +196,9 @@ parla_tray_install_reopen_handler (void)
 		class_addMethod (subclass,
 		                 @selector (applicationShouldHandleReopen:hasVisibleWindows:),
 		                 (IMP) parla_tray_should_handle_reopen, "c@:@c");
+		class_addMethod (subclass,
+		                 @selector (applicationDidBecomeActive:),
+		                 (IMP) parla_tray_did_become_active, "v@:@");
 		objc_registerClassPair (subclass);
 	}
 


### PR DESCRIPTION
## What

Fixes the slow Dock reopen on macOS. Closing the Parla window hides
it; clicking the Dock icon took several seconds (sometimes ~12s) to
bring it back, while a second click was instant.

## Why

The Dock reopen path deferred the window show through `g_idle_add`.
With the window hidden, the GLib main loop does not wake up promptly
to dispatch that idle, so the first click waited on the main loop
instead of showing the window.

## How

The AppKit `applicationShouldHandleReopen:hasVisibleWindows:` and
`applicationDidBecomeActive:` callbacks now present the window
synchronously via `parla_tray_show_window_now()`, with a guard so the
two callbacks from one Dock click only trigger a single show. This is
safe because both callbacks run on the main thread during ordinary
AppKit event processing.

## Testing

- `make run` on macOS
- close window → wait → click Dock icon: window reappears instantly
- repeat cycles and second clicks behave correctly
- `meson test -C builddir` passes (8/8)