### PR TITLE
Show Desktop Entry in Phosh - Notify about mobile Linux compatibilty

### DIFF
--- a/data/io.github.trufae.Parla.desktop
+++ b/data/io.github.trufae.Parla.desktop
@@ -11,3 +11,4 @@ Keywords=chat;messaging;email;deltachat;parla;
 MimeType=x-scheme-handler/openpgp4fpr;
 StartupNotify=true
 DBusActivatable=true
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
The phosh desktop entry uses this line to know that this app need to be listet in the mobile view too.