### PR TITLE
Add Windows accessibility support via AccessKit backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,8 @@ jobs:
             zip
             unzip
             curl
+            git
+            base-devel
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-meson
             mingw-w64-ucrt-x86_64-vala
@@ -212,6 +214,30 @@ jobs:
             mingw-w64-ucrt-x86_64-librsvg
             mingw-w64-ucrt-x86_64-webp-pixbuf-loader
             mingw-w64-ucrt-x86_64-ntldd
+
+      # Windows screen readers only see GTK through its AccessKit
+      # backend, which MSYS2's gtk4 does not enable, so the package is
+      # rebuilt with it (scripts/windows/gtk4-accesskit.sh). The cache
+      # keys on the upstream PKGBUILD version the script builds from,
+      # so the ~30 minute rebuild happens once per gtk4 release.
+      - name: Compute gtk4 rebuild cache key
+        id: gtk4
+        run: |
+          ver="$(curl -sSL https://raw.githubusercontent.com/msys2/MINGW-packages/master/mingw-w64-gtk4/PKGBUILD \
+            | awk -F= '/^pkgver=/ { v = $2 } /^pkgrel=/ { r = $2 } END { print v "-" r }')"
+          if [ -z "$ver" ] || [ "$ver" = "-" ]; then
+            ver="$(pacman -Si mingw-w64-ucrt-x86_64-gtk4 | awk '/^Version/ { print $3; exit }')"
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Cache AccessKit-enabled gtk4 packages
+        uses: actions/cache@v4
+        with:
+          path: .cache/msys2-a11y-pkgs
+          key: msys2-gtk4-accesskit-${{ steps.gtk4.outputs.version }}
+
+      - name: Rebuild gtk4 with the AccessKit a11y backend
+        run: bash scripts/windows/gtk4-accesskit.sh
 
       - name: Build and bundle
         run: WITH_WEBXDC=1 bash scripts/windows/bundle.sh

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ src/config.vala
 .codex/
 scripts/stickers/.tools/
 ./*.zip
+.cache/
+builddir-gtk4-accesskit/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Want to build it yourself? See [Build](#build) below.
 - **Choose the conversation layout** &mdash; use familiar bubbles, compact IRC-style lines, or workspace rows. The split view adapts to narrow and phone-sized windows, where the sidebar becomes a single-pane navigation view.
 - **Keyboard-first when you want it** &mdash; quickly switch chats, create conversations, search, navigate, and focus the composer without leaving the keyboard.
 - **Desktop-aware** &mdash; configurable notifications, a tray icon for keeping Parla available in the background, and support for multiple accounts.
+- **Screen-reader support** &mdash; works with Orca on Linux; Windows builds ship GTK with the AccessKit backend so NVDA and JAWS can read the interface. See [docs/accessibility.md](docs/accessibility.md).
 
 ## More features
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,76 @@
+# Screen reader support
+
+How Parla is exposed to screen readers on each platform, and what the
+Windows/macOS bundles must ship for that to work at all.
+
+## How GTK accessibility works per platform
+
+GTK 4 keeps an internal accessibility tree (roles, labels, states) and
+exposes it through a platform backend chosen at runtime from the
+backends compiled into GTK:
+
+- **Linux**: the AT-SPI backend, always compiled in, talks to the
+  AT-SPI bus over D-Bus. Orca works with stock distro GTK; nothing
+  special is needed in our packages.
+- **Windows**: screen readers (NVDA, JAWS, Narrator) consume
+  **UI Automation**. GTK only speaks UI Automation through its
+  **AccessKit** backend (GTK >= 4.18, build option
+  `-Daccesskit=enabled`, implemented by the `accesskit-c` library).
+  A GTK built without it exposes *nothing*: the window is an empty
+  rectangle to a screen reader, no matter what the app does.
+- **macOS**: same situation — VoiceOver is only reachable through the
+  AccessKit backend.
+
+The backend is selected automatically: in a win32-only GTK build with
+AccessKit compiled in, AccessKit is the only real backend and is used
+by default; no `GTK_A11Y` environment variable is needed.
+`GTK_A11Y=help` prints the backends a given build carries, which is
+the quickest way to check a bundle.
+
+## Windows bundle contract
+
+MSYS2's stock `gtk4` package is built **without** the AccessKit
+backend (and its `accesskit-c` package lags behind the version GTK's
+meson build requires), so a bundle made purely from stock MSYS2
+packages is unreadable by NVDA/JAWS. Therefore:
+
+- CI rebuilds the MSYS2 `gtk4` package with `-Daccesskit=enabled`,
+  building a matching `accesskit-c` first when the MSYS2 repo version
+  is too old: `scripts/windows/gtk4-accesskit.sh`. The script reuses
+  MSYS2's own PKGBUILDs (same patches, same options) and only adds the
+  accessibility bits; built packages are cached per gtk4 release so
+  the rebuild cost is paid once per version bump.
+- `scripts/windows/bundle.sh` refuses to produce a zip whose
+  `libgtk-4-1.dll` lacks the AccessKit backend, and checks that the
+  `libaccesskit` DLL made it into `bin/` (the ntldd closure picks it
+  up like any other GTK dependency). Set `REQUIRE_A11Y=0` only for
+  local throwaway builds against a stock GTK.
+- If MSYS2 ever enables AccessKit in its own gtk4 package, the rebuild
+  script detects that and becomes a no-op; it can then be deleted.
+
+## Testing with NVDA
+
+NVDA is free: <https://www.nvaccess.org/download/> (a portable version
+exists, no install needed).
+
+1. Start NVDA, then start Parla.
+2. Tab / Shift+Tab through the window: every focused control should be
+   announced with a sensible name and role ("Search, edit", "Send,
+   button", ...).
+3. Arrow through the chat list and messages; NVDA should read rows as
+   they gain focus.
+4. `GTK_A11Y=help parla.exe` from a console lists the compiled-in
+   backends; "accesskit" must appear for any of the above to work.
+
+## App-side rules
+
+A working backend only exposes what widgets declare, so:
+
+- Icon-only buttons need an accessible name: set `tooltip_text` (GTK
+  falls back to it) or call
+  `update_property (Gtk.AccessibleProperty.LABEL, "...", -1)`.
+- Composite rows (chat list, message rows) should carry a label
+  summarizing their content, otherwise screen readers announce an
+  unnamed list item.
+- Purely decorative images/widgets should not be announced; give them
+  `Gtk.AccessibleRole.PRESENTATION`.

--- a/scripts/windows/bundle.sh
+++ b/scripts/windows/bundle.sh
@@ -104,6 +104,28 @@ if ! find "$BIN" -maxdepth 1 -type f -iname 'libwebp*.dll' \
     exit 1
 fi
 
+# Screen reader support: NVDA/JAWS only see GTK on Windows through its
+# AccessKit backend (a UI Automation bridge), which the stock MSYS2
+# gtk4 does not compile in. CI rebuilds gtk4 with the backend enabled
+# (scripts/windows/gtk4-accesskit.sh); refuse to ship a GTK that would
+# present an empty window to screen readers. REQUIRE_A11Y=0 skips the
+# check for local builds against a stock GTK.
+if [ "${REQUIRE_A11Y:-1}" = "1" ]; then
+    if ! objdump -p "$BIN/libgtk-4-1.dll" | grep -qi accesskit \
+        && ! strings -a "$BIN/libgtk-4-1.dll" | grep -qw accesskit; then
+        echo "error: bundled GTK lacks the AccessKit accessibility backend;" >&2
+        echo "       run scripts/windows/gtk4-accesskit.sh first, or set REQUIRE_A11Y=0" >&2
+        echo "       to build a bundle that Windows screen readers cannot read" >&2
+        exit 1
+    fi
+    accesskit_dll="$(objdump -p "$BIN/libgtk-4-1.dll" \
+        | awk 'tolower($0) ~ /dll name:.*accesskit/ { print $3; exit }')"
+    if [ -n "$accesskit_dll" ] && [ ! -f "$BIN/$accesskit_dll" ]; then
+        echo "error: bundled GTK imports $accesskit_dll but the DLL closure did not ship it" >&2
+        exit 1
+    fi
+fi
+
 # GSettings schemas: GTK aborts on startup paths that touch
 # org.gtk.gtk4.Settings.* when the compiled schemas are missing.
 mkdir -p "$DIST/share/glib-2.0/schemas"

--- a/scripts/windows/gtk4-accesskit.sh
+++ b/scripts/windows/gtk4-accesskit.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Rebuild the MSYS2 gtk4 package with the AccessKit accessibility
+# backend so Windows screen readers (NVDA, JAWS, Narrator) can read
+# the Parla window.
+#
+# Background: GTK has no accessibility support on Windows unless it is
+# configured with -Daccesskit=enabled (available since GTK 4.18); the
+# AccessKit backend bridges GTK's accessibility tree to UI Automation,
+# which is what screen readers consume. MSYS2's stock gtk4 package is
+# built without it, and its accesskit-c package lags behind the
+# version GTK requires, so a bundle made from stock packages presents
+# an empty window to NVDA. This script rebuilds both packages from
+# MSYS2's own PKGBUILDs, changing only what accessibility needs:
+#   - accesskit-c: pkgver bumped to the release GTK's meson.build asks
+#     for (e.g. accesskit-c-0.18);
+#   - gtk4: -Daccesskit=enabled added to the meson options and
+#     accesskit-c added to depends.
+#
+# Must run in an MSYS2 UCRT64 shell with base-devel and git installed
+# (makepkg-mingw comes from base-devel). Built packages are installed
+# with pacman -U and copied into PKG_CACHE so CI can restore them and
+# skip the ~30 minute GTK build until the next gtk4 version bump.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PREFIX="${MINGW_PREFIX:-/ucrt64}"
+PKGPREFIX="${MINGW_PACKAGE_PREFIX:-mingw-w64-ucrt-x86_64}"
+PKG_CACHE="${PKG_CACHE:-$ROOT/.cache/msys2-a11y-pkgs}"
+WORK="${WORK_DIR:-$ROOT/builddir-gtk4-accesskit}"
+MINGW_PACKAGES_GIT="https://github.com/msys2/MINGW-packages"
+ACCESSKIT_C_GIT="https://github.com/AccessKit/accesskit-c"
+
+GTK_DLL="$PREFIX/bin/libgtk-4-1.dll"
+
+# The backend is compiled in, so its witness is in the DLL: an import
+# of libaccesskit.dll in the normal (shared) case, or at least the
+# backend's name string if it was ever linked statically.
+gtk_has_accesskit() {
+    objdump -p "$GTK_DLL" 2>/dev/null | grep -qi accesskit \
+        || strings -a "$GTK_DLL" 2>/dev/null | grep -qw accesskit
+}
+
+if gtk_has_accesskit; then
+    echo "gtk4-accesskit: installed GTK already carries the AccessKit backend, nothing to do"
+    exit 0
+fi
+
+command -v makepkg-mingw >/dev/null || {
+    echo "error: makepkg-mingw not found; install the MSYS2 base-devel group" >&2
+    exit 1
+}
+
+# MSYS2's own PKGBUILDs, sparse-cloned so we track their patches and
+# meson options exactly and only diverge where accessibility needs it.
+rm -rf "$WORK"
+mkdir -p "$WORK"
+git clone --depth 1 --filter=blob:none --sparse "$MINGW_PACKAGES_GIT" \
+    "$WORK/MINGW-packages"
+git -C "$WORK/MINGW-packages" sparse-checkout set \
+    mingw-w64-gtk4 mingw-w64-accesskit-c
+GTK_PKGDIR="$WORK/MINGW-packages/mingw-w64-gtk4"
+AK_PKGDIR="$WORK/MINGW-packages/mingw-w64-accesskit-c"
+
+gtk_fullver="$(awk -F= '/^pkgver=/ { v = $2 } /^pkgrel=/ { r = $2 }
+                        END { print v "-" r }' "$GTK_PKGDIR/PKGBUILD")"
+
+# Cached packages from a previous run of this script; pacman resolves
+# any missing dependency (e.g. a repo accesskit-c) from the sync repos.
+shopt -s nullglob
+cached=("$PKG_CACHE/$PKGPREFIX-gtk4-$gtk_fullver-any.pkg.tar."*)
+if [ "${#cached[@]}" -gt 0 ]; then
+    echo "gtk4-accesskit: installing cached packages for gtk4 $gtk_fullver"
+    if pacman -U --noconfirm "$PKG_CACHE"/*.pkg.tar.* && gtk_has_accesskit; then
+        echo "gtk4-accesskit: done (from cache)"
+        exit 0
+    fi
+    echo "gtk4-accesskit: cached packages unusable, rebuilding" >&2
+fi
+
+# Fetch and extract the GTK source first to learn which accesskit-c
+# API version this GTK release requires (its meson.build names the
+# pkg-config module, e.g. accesskit-c-0.18).
+(cd "$GTK_PKGDIR" && MINGW_ARCH="$MSYSTEM" makepkg-mingw \
+    --nobuild --nodeps --noconfirm --skippgpcheck)
+ak_module="$(grep -ohE "accesskit-c-[0-9]+\.[0-9]+" \
+    "$GTK_PKGDIR"/src/gtk-*/meson.build | head -n1)"
+if [ -z "$ak_module" ]; then
+    echo "error: could not determine the accesskit-c version GTK requires" >&2
+    exit 1
+fi
+ak_minor="${ak_module#accesskit-c-}"
+echo "gtk4-accesskit: gtk4 $gtk_fullver requires $ak_module"
+
+# Provide accesskit-c: already installed, from the MSYS2 repo if it
+# has caught up, or built from the same PKGBUILD with pkgver bumped to
+# the newest matching upstream tag.
+if pkg-config --exists "$ak_module"; then
+    echo "gtk4-accesskit: $ak_module already installed"
+else
+    repo_ak="$(pacman -Si "$PKGPREFIX-accesskit-c" 2>/dev/null \
+        | awk '/^Version/ { print $3; exit }')"
+    case "$repo_ak" in
+    "$ak_minor".*)
+        pacman -S --noconfirm "$PKGPREFIX-accesskit-c"
+        ;;
+    *)
+        ak_tag="$(git ls-remote --tags "$ACCESSKIT_C_GIT" "refs/tags/$ak_minor.*" \
+            | awk -F/ '{ print $NF }' \
+            | grep -E "^${ak_minor//./\\.}\.[0-9]+$" \
+            | sort -V | tail -n1)"
+        if [ -z "$ak_tag" ]; then
+            echo "error: no accesskit-c release tag matches $ak_module" >&2
+            exit 1
+        fi
+        echo "gtk4-accesskit: building accesskit-c $ak_tag"
+        sed -i "s|^pkgver=.*|pkgver=$ak_tag|" "$AK_PKGDIR/PKGBUILD"
+        sed -i "s|^sha256sums=.*|sha256sums=('SKIP')|" "$AK_PKGDIR/PKGBUILD"
+        (cd "$AK_PKGDIR" && MINGW_ARCH="$MSYSTEM" makepkg-mingw \
+            --syncdeps --noconfirm --skippgpcheck --nocheck --force)
+        pacman -U --noconfirm "$AK_PKGDIR"/*.pkg.tar.*
+        ;;
+    esac
+    pkg-config --exists "$ak_module" || {
+        echo "error: $ak_module still not found after installing accesskit-c" >&2
+        exit 1
+    }
+fi
+
+# Rebuild gtk4 with the backend. Both seds are verified so drift in
+# the upstream PKGBUILD fails loudly instead of silently shipping an
+# inaccessible GTK again.
+sed -i 's|-Dwin32-backend=true \\|-Dwin32-backend=true \\\n    -Daccesskit=enabled \\|' \
+    "$GTK_PKGDIR/PKGBUILD"
+grep -q -- '-Daccesskit=enabled' "$GTK_PKGDIR/PKGBUILD" || {
+    echo "error: failed to add -Daccesskit=enabled to the gtk4 PKGBUILD" >&2
+    exit 1
+}
+sed -i 's|-shared-mime-info")|-shared-mime-info"\n         "${MINGW_PACKAGE_PREFIX}-accesskit-c")|' \
+    "$GTK_PKGDIR/PKGBUILD"
+grep -q -- '-accesskit-c")' "$GTK_PKGDIR/PKGBUILD" || {
+    echo "error: failed to add accesskit-c to the gtk4 depends" >&2
+    exit 1
+}
+
+echo "gtk4-accesskit: building gtk4 $gtk_fullver with -Daccesskit=enabled"
+(cd "$GTK_PKGDIR" && MINGW_ARCH="$MSYSTEM" makepkg-mingw \
+    --syncdeps --noconfirm --skippgpcheck --nocheck --force)
+pacman -U --noconfirm "$GTK_PKGDIR"/*.pkg.tar.*
+
+gtk_has_accesskit || {
+    echo "error: rebuilt libgtk-4-1.dll still lacks the AccessKit backend" >&2
+    exit 1
+}
+
+mkdir -p "$PKG_CACHE"
+rm -f "$PKG_CACHE"/*.pkg.tar.*
+cp "$GTK_PKGDIR"/*.pkg.tar.* "$PKG_CACHE/"
+cp "$AK_PKGDIR"/*.pkg.tar.* "$PKG_CACHE/" 2>/dev/null || true
+rm -rf "$WORK"
+echo "gtk4-accesskit: done"


### PR DESCRIPTION
## Summary

This PR adds screen reader support for Windows by enabling GTK's AccessKit accessibility backend. Windows screen readers (NVDA, JAWS, Narrator) can only access GTK applications through UI Automation, which requires the AccessKit backend to be compiled into GTK. MSYS2's stock gtk4 package doesn't include this, so we rebuild it with the necessary changes.

## Key Changes

- **New script `scripts/windows/gtk4-accesskit.sh`**: Rebuilds MSYS2's gtk4 and accesskit-c packages with accessibility support enabled. The script:
  - Clones MSYS2's PKGBUILD repositories to preserve their patches and build options
  - Determines which accesskit-c version GTK requires from its meson.build
  - Builds accesskit-c if the MSYS2 repo version is too old
  - Rebuilds gtk4 with `-Daccesskit=enabled` and adds accesskit-c as a dependency
  - Caches built packages per gtk4 release to avoid rebuilding on every CI run
  - Verifies the resulting DLL contains the AccessKit backend

- **Updated `scripts/windows/bundle.sh`**: Adds validation to ensure bundled GTK has the AccessKit backend compiled in, preventing accidental distribution of inaccessible builds. Can be skipped with `REQUIRE_A11Y=0` for local development.

- **Updated `.github/workflows/ci.yml`**: 
  - Adds git and base-devel to MSYS2 dependencies (required for makepkg-mingw)
  - Computes gtk4 version from upstream PKGBUILD to create stable cache keys
  - Caches rebuilt packages per gtk4 release
  - Runs the gtk4 rebuild script before bundling

- **New documentation `docs/accessibility.md`**: Explains how GTK accessibility works per platform, the Windows bundle requirements, and testing procedures with NVDA.

- **Updated `.gitignore`**: Ignores the build cache directory and temporary build artifacts.

## Implementation Details

- The script detects if GTK already has AccessKit by checking the DLL for imports or symbol strings, making it a no-op if already present
- Uses sparse git cloning to efficiently fetch only the needed PKGBUILD files
- Validates all sed modifications to the PKGBUILD to catch upstream drift loudly
- Verifies the AccessKit DLL is included in the bundle's dependency closure
