### PR TITLE
Make macOS builds readable by VoiceOver (AccessKit backend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,24 @@ jobs:
             glib-networking \
             adwaita-icon-theme
 
+      # VoiceOver only sees GTK through its AccessKit backend, which
+      # Homebrew's gtk4 does not enable, so the library is rebuilt
+      # with it (scripts/macos/gtk4-accesskit.sh). The cache keys on
+      # the installed gtk4 version, so the rebuild happens once per
+      # gtk4 release and runner flavor.
+      - name: Compute gtk4 rebuild cache key
+        id: gtk4
+        run: echo "version=$(brew list --versions gtk4 | awk '{ print $2; exit }')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache AccessKit-enabled GTK libraries
+        uses: actions/cache@v4
+        with:
+          path: .cache/macos-a11y-libs
+          key: macos-gtk4-accesskit-${{ matrix.dmgname }}-${{ steps.gtk4.outputs.version }}
+
+      - name: Rebuild gtk4 with the AccessKit a11y backend
+        run: scripts/macos/gtk4-accesskit.sh
+
       - name: Build
         run: make BUILDTYPE=release WITH_WEBXDC=1
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Want to build it yourself? See [Build](#build) below.
 - **Choose the conversation layout** &mdash; use familiar bubbles, compact IRC-style lines, or workspace rows. The split view adapts to narrow and phone-sized windows, where the sidebar becomes a single-pane navigation view.
 - **Keyboard-first when you want it** &mdash; quickly switch chats, create conversations, search, navigate, and focus the composer without leaving the keyboard.
 - **Desktop-aware** &mdash; configurable notifications, a tray icon for keeping Parla available in the background, and support for multiple accounts.
-- **Screen-reader support** &mdash; works with Orca on Linux; Windows builds ship GTK with the AccessKit backend so NVDA and JAWS can read the interface. See [docs/accessibility.md](docs/accessibility.md).
+- **Screen-reader support** &mdash; works with Orca on Linux; Windows and macOS builds ship GTK with the AccessKit backend so NVDA, JAWS and VoiceOver can read the interface. See [docs/accessibility.md](docs/accessibility.md).
 
 ## More features
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -19,7 +19,7 @@ backends compiled into GTK:
   A GTK built without it exposes *nothing*: the window is an empty
   rectangle to a screen reader, no matter what the app does.
 - **macOS**: same situation — VoiceOver is only reachable through the
-  AccessKit backend.
+  AccessKit backend (bridged to NSAccessibility).
 
 The backend is selected automatically: in a win32-only GTK build with
 AccessKit compiled in, AccessKit is the only real backend and is used
@@ -47,6 +47,40 @@ packages is unreadable by NVDA/JAWS. Therefore:
   local throwaway builds against a stock GTK.
 - If MSYS2 ever enables AccessKit in its own gtk4 package, the rebuild
   script detects that and becomes a no-op; it can then be deleted.
+
+## macOS bundle contract
+
+Homebrew's gtk4 bottle has the same gap (and Homebrew carries no
+accesskit-c formula at all), so:
+
+- CI rebuilds the same GTK release Homebrew installed from the
+  upstream tarball with the formula's macOS meson arguments plus
+  `-Daccesskit=enabled`, building accesskit-c first:
+  `scripts/macos/gtk4-accesskit.sh`. Only `libgtk-4*.dylib` is
+  replaced — in both `$(brew --prefix)/lib` and the gtk4 keg, because
+  libadwaita and the gtk modules reference GTK through the keg's opt
+  path. Headers and pkg-config files are identical for the same
+  release, so the app build is untouched. The built dylibs are cached
+  per gtk4 version and runner flavor.
+- `scripts/macos/bundle.sh` refuses to produce an app bundle whose
+  `libgtk-4.1.dylib` lacks the AccessKit backend, and checks that the
+  `libaccesskit` dylib made it into `Frameworks/` (the Mach-O closure
+  picks it up like any other dependency). Set `REQUIRE_A11Y=0` only
+  for local throwaway builds against a stock GTK.
+- If Homebrew ever ships gtk4 with AccessKit, the rebuild script
+  detects that and becomes a no-op; it can then be deleted.
+
+To smoke-test: turn on VoiceOver (Cmd+F5), start Parla, and move
+focus with Tab / VO-arrows; controls should be announced with names
+and roles.
+
+## Linux packaging
+
+Nothing special is required, but for the record: the deb uses distro
+GTK; the Flatpak uses the GNOME runtime's GTK and Flatpak proxies the
+accessibility bus by default (the manifest must never pass
+`--no-a11y-bus`); the AppImage bundles a distro GTK whose AT-SPI
+backend talks to the host a11y bus over D-Bus.
 
 ## Testing with NVDA
 

--- a/scripts/macos/bundle.sh
+++ b/scripts/macos/bundle.sh
@@ -303,16 +303,17 @@ fi
 # local builds against a stock GTK.
 if [ "${REQUIRE_A11Y:-1}" = "1" ]; then
     bundled_gtk="$FRAMEWORKS/libgtk-4.1.dylib"
-    if ! otool -L "$bundled_gtk" | grep -qi accesskit \
-        && ! strings "$bundled_gtk" | grep -qw accesskit; then
+    # The witness is the load command for the accesskit dylib — never
+    # a strings scan, since a stock GTK contains the literal help text
+    # "accesskit - Disabled during GTK build".
+    if ! otool -L "$bundled_gtk" | grep -qi accesskit; then
         echo "error: bundled GTK lacks the AccessKit accessibility backend;" >&2
         echo "       run scripts/macos/gtk4-accesskit.sh first, or set REQUIRE_A11Y=0" >&2
         echo "       to build a bundle that VoiceOver cannot read" >&2
         exit 1
     fi
-    if otool -L "$bundled_gtk" | grep -qi accesskit \
-        && ! find "$FRAMEWORKS" -maxdepth 1 -name 'libaccesskit*.dylib' \
-            -print -quit | grep -q .; then
+    if ! find "$FRAMEWORKS" -maxdepth 1 -name 'libaccesskit*.dylib' \
+        -print -quit | grep -q .; then
         echo "error: bundled GTK links AccessKit but no libaccesskit dylib was bundled" >&2
         exit 1
     fi

--- a/scripts/macos/bundle.sh
+++ b/scripts/macos/bundle.sh
@@ -296,6 +296,28 @@ if otool -L "$webp_loader" | grep -qE "$BREW_PREFIX|/usr/local"; then
     exit 1
 fi
 
+# Screen reader support: VoiceOver only sees GTK through its AccessKit
+# backend, which Homebrew's stock gtk4 does not compile in.
+# scripts/macos/gtk4-accesskit.sh rebuilds it; refuse to ship an app
+# bundle VoiceOver cannot read. REQUIRE_A11Y=0 skips the check for
+# local builds against a stock GTK.
+if [ "${REQUIRE_A11Y:-1}" = "1" ]; then
+    bundled_gtk="$FRAMEWORKS/libgtk-4.1.dylib"
+    if ! otool -L "$bundled_gtk" | grep -qi accesskit \
+        && ! strings "$bundled_gtk" | grep -qw accesskit; then
+        echo "error: bundled GTK lacks the AccessKit accessibility backend;" >&2
+        echo "       run scripts/macos/gtk4-accesskit.sh first, or set REQUIRE_A11Y=0" >&2
+        echo "       to build a bundle that VoiceOver cannot read" >&2
+        exit 1
+    fi
+    if otool -L "$bundled_gtk" | grep -qi accesskit \
+        && ! find "$FRAMEWORKS" -maxdepth 1 -name 'libaccesskit*.dylib' \
+            -print -quit | grep -q .; then
+        echo "error: bundled GTK links AccessKit but no libaccesskit dylib was bundled" >&2
+        exit 1
+    fi
+fi
+
 if command -v gio-querymodules >/dev/null 2>&1 && [ -d "$RESOURCES/lib/gio/modules" ]; then
     gio-querymodules "$RESOURCES/lib/gio/modules"
 fi

--- a/scripts/macos/gtk4-accesskit.sh
+++ b/scripts/macos/gtk4-accesskit.sh
@@ -55,11 +55,12 @@ STAGE_CACHE="$CACHE_DIR/gtk4-$gtk_ver"
 
 deploy_stage() {
     local stage="$1" f base
-    # No dir times or ownership: on Intel BREW_PREFIX is /usr/local,
-    # whose top directory is root-owned, and restoring its mtime makes
-    # rsync fail with utimensat EPERM (exit 23) even though every file
-    # lands fine.
-    rsync -a --omit-dir-times --no-owner --no-group "$stage/" "$BREW_PREFIX/"
+    # -rlt only, no -a: on Intel BREW_PREFIX is /usr/local, whose
+    # directories are root-owned, and any attempt to restore their
+    # metadata (mtime via utimensat, mode via fchmodat) fails with
+    # EPERM and kills rsync with exit 23 even though every file lands
+    # fine. Copy files and symlinks, touch no existing directory.
+    rsync -rlt --omit-dir-times "$stage/" "$BREW_PREFIX/"
     # Keep the keg copy identical: libadwaita and the gtk modules load
     # GTK through the keg's opt path, and a second, backend-less GTK
     # there would race ours for the one slot in the app bundle.
@@ -134,7 +135,9 @@ if ! pkg-config --exists "$ak_module"; then
         fi
     done
     rsync -a "$ak_stage/" "$STAGE/"
-    rsync -a --omit-dir-times --no-owner --no-group "$ak_stage/" "$BREW_PREFIX/"
+    # Same flags as deploy_stage: never touch existing directory
+    # metadata under the (possibly root-owned) Homebrew prefix.
+    rsync -rlt --omit-dir-times "$ak_stage/" "$BREW_PREFIX/"
     if ! pkg-config --exists "$ak_module"; then
         echo "error: $ak_module still not found after installing accesskit-c" >&2
         exit 1

--- a/scripts/macos/gtk4-accesskit.sh
+++ b/scripts/macos/gtk4-accesskit.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Rebuild Homebrew's gtk4 library with the AccessKit accessibility
+# backend so VoiceOver can read the Parla window.
+#
+# Background: GTK has no accessibility support on macOS unless it is
+# configured with -Daccesskit=enabled (available since GTK 4.18); the
+# AccessKit backend bridges GTK's accessibility tree to NSAccessibility,
+# which is what VoiceOver consumes. Homebrew's gtk4 bottle is built
+# without it and Homebrew has no accesskit-c formula at all, so a
+# bundle made from stock bottles presents an empty window to VoiceOver.
+#
+# This script builds accesskit-c (the version GTK's meson.build asks
+# for) and the same GTK release Homebrew installed, from the upstream
+# tarballs with the Homebrew formula's macOS meson arguments plus
+# -Daccesskit=enabled, then replaces libgtk-4 in both the Homebrew
+# prefix and the gtk4 keg — the keg copy matters because libadwaita
+# and the gtk modules reference GTK through the keg's opt path. Only
+# the dylibs are replaced: headers and pkg-config files are identical
+# for the same release, so the app build itself is untouched.
+#
+# The installed libraries are staged into A11Y_CACHE_DIR so CI can
+# restore them and skip the rebuild until the next gtk4 version bump.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$ROOT/scripts/macos/env.sh"
+
+CACHE_DIR="${A11Y_CACHE_DIR:-$ROOT/.cache/macos-a11y-libs}"
+WORK="${WORK_DIR:-$ROOT/builddir-gtk4-accesskit}"
+ACCESSKIT_C_GIT="https://github.com/AccessKit/accesskit-c"
+
+GTK_LIB="$BREW_PREFIX/lib/libgtk-4.1.dylib"
+
+# The backend is compiled in, so its witness is in the library: a
+# load command for libaccesskit in the normal (shared) case, or at
+# least the backend's name string if it was ever linked statically.
+gtk_has_accesskit() {
+    otool -L "$1" 2>/dev/null | grep -qi accesskit \
+        || strings "$1" 2>/dev/null | grep -qw accesskit
+}
+
+if gtk_has_accesskit "$GTK_LIB"; then
+    echo "gtk4-accesskit: installed GTK already carries the AccessKit backend, nothing to do"
+    exit 0
+fi
+
+GTK_KEG="$(brew --prefix gtk4)"
+gtk_ver="$(brew list --versions gtk4 | awk '{ print $2; exit }')"
+if [ -z "$gtk_ver" ]; then
+    echo "error: Homebrew gtk4 is not installed" >&2
+    exit 1
+fi
+src_ver="${gtk_ver%%_*}"
+STAGE_CACHE="$CACHE_DIR/gtk4-$gtk_ver"
+
+deploy_stage() {
+    local stage="$1" f base
+    rsync -a "$stage/" "$BREW_PREFIX/"
+    # Keep the keg copy identical: libadwaita and the gtk modules load
+    # GTK through the keg's opt path, and a second, backend-less GTK
+    # there would race ours for the one slot in the app bundle.
+    for f in "$stage"/lib/libgtk-4*.dylib; do
+        base="$(basename "$f")"
+        rm -f "$GTK_KEG/lib/$base"
+        cp -a "$f" "$GTK_KEG/lib/$base"
+    done
+}
+
+if [ -d "$STAGE_CACHE" ]; then
+    echo "gtk4-accesskit: installing cached libraries for gtk4 $gtk_ver"
+    if deploy_stage "$STAGE_CACHE" && gtk_has_accesskit "$GTK_LIB"; then
+        echo "gtk4-accesskit: done (from cache)"
+        exit 0
+    fi
+    echo "gtk4-accesskit: cached libraries unusable, rebuilding" >&2
+fi
+
+command -v cargo >/dev/null || brew install rust
+command -v sass >/dev/null || brew install dart-sass
+# msgfmt for GTK's translations; Homebrew's gettext is keg-only.
+export PATH="$BREW_PREFIX/opt/gettext/bin:$PATH"
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+STAGE="$WORK/stage"
+mkdir -p "$STAGE/lib"
+
+# The GTK source matching the installed bottle; its meson.build names
+# the accesskit-c pkg-config module this release requires.
+curl -L --fail --silent --show-error \
+    "https://download.gnome.org/sources/gtk/${src_ver%.*}/gtk-$src_ver.tar.xz" \
+    -o "$WORK/gtk.tar.xz"
+tar -xf "$WORK/gtk.tar.xz" -C "$WORK"
+GTK_SRC="$WORK/gtk-$src_ver"
+ak_module="$(grep -ohE "accesskit-c-[0-9]+\.[0-9]+" "$GTK_SRC/meson.build" | head -n1)"
+if [ -z "$ak_module" ]; then
+    echo "error: could not determine the accesskit-c version GTK requires" >&2
+    exit 1
+fi
+echo "gtk4-accesskit: gtk4 $gtk_ver requires $ak_module"
+
+if ! pkg-config --exists "$ak_module"; then
+    ak_minor="${ak_module#accesskit-c-}"
+    ak_tag="$(git ls-remote --tags "$ACCESSKIT_C_GIT" "refs/tags/$ak_minor.*" \
+        | awk -F/ '{ print $NF }' \
+        | grep -E "^${ak_minor//./\\.}\.[0-9]+$" \
+        | sort -V | tail -n1)"
+    if [ -z "$ak_tag" ]; then
+        echo "error: no accesskit-c release tag matches $ak_module" >&2
+        exit 1
+    fi
+    echo "gtk4-accesskit: building accesskit-c $ak_tag"
+    curl -L --fail --silent --show-error \
+        "$ACCESSKIT_C_GIT/archive/refs/tags/$ak_tag.tar.gz" \
+        -o "$WORK/accesskit-c.tar.gz"
+    tar -xf "$WORK/accesskit-c.tar.gz" -C "$WORK"
+    meson setup "$WORK/build-accesskit" "$WORK/accesskit-c-$ak_tag" \
+        --prefix="$BREW_PREFIX" --buildtype=release
+    meson compile -C "$WORK/build-accesskit"
+    meson install -C "$WORK/build-accesskit" --destdir "$WORK/destdir-accesskit"
+    ak_stage="$WORK/destdir-accesskit$BREW_PREFIX"
+    # An absolute install name lets both GTK's link step and the
+    # bundler's closure resolve the library without rpath games.
+    for f in "$ak_stage"/lib/libaccesskit*.dylib; do
+        [ -L "$f" ] && continue
+        want="$BREW_PREFIX/lib/$(basename "$f")"
+        if [ "$(otool -D "$f" | tail -n1)" != "$want" ]; then
+            install_name_tool -id "$want" "$f"
+            codesign --force --sign - "$f"
+        fi
+    done
+    rsync -a "$ak_stage/" "$STAGE/"
+    rsync -a "$ak_stage/" "$BREW_PREFIX/"
+    if ! pkg-config --exists "$ak_module"; then
+        echo "error: $ak_module still not found after installing accesskit-c" >&2
+        exit 1
+    fi
+fi
+
+echo "gtk4-accesskit: building gtk4 $src_ver with -Daccesskit=enabled"
+# Same tweak Homebrew applies: the tarball's theme build calls the
+# deprecated sassc, dart-sass replaces it.
+sed -i '' "s|'sassc'|'sass'|g" "$GTK_SRC/gtk/meson.build"
+sed -i '' "s|'-a', '-M', '-t', 'compact'|'--style', 'compressed'|g" \
+    "$GTK_SRC/gtk/meson.build"
+# Match the bottle's flags; man pages and introspection are skipped
+# because only the dylibs are taken from this build.
+export CPPFLAGS="${CPPFLAGS:-} -DG_DISABLE_ASSERT -DG_DISABLE_CAST_CHECKS"
+meson setup "$WORK/build-gtk" "$GTK_SRC" \
+    --prefix="$BREW_PREFIX" --buildtype=release --wrap-mode=nofallback \
+    -Dbuild-examples=false \
+    -Dbuild-tests=false \
+    -Dbuild-testsuite=false \
+    -Dintrospection=disabled \
+    -Dman-pages=false \
+    -Dmedia-gstreamer=disabled \
+    -Dvulkan=disabled \
+    -Dx11-backend=false \
+    -Dmacos-backend=true \
+    -Daccesskit=enabled
+meson compile -C "$WORK/build-gtk"
+meson install -C "$WORK/build-gtk" --destdir "$WORK/destdir-gtk"
+gtk_stage="$WORK/destdir-gtk$BREW_PREFIX"
+gtk_dylib="$gtk_stage/lib/libgtk-4.1.dylib"
+if [ ! -f "$gtk_dylib" ]; then
+    echo "error: the GTK build produced no libgtk-4.1.dylib" >&2
+    exit 1
+fi
+install_name_tool -id "$BREW_PREFIX/lib/libgtk-4.1.dylib" "$gtk_dylib"
+dep="$(otool -L "$gtk_dylib" | awk '/accesskit/ { print $1; exit }')"
+case "$dep" in
+"@rpath"/*)
+    install_name_tool -change "$dep" "$BREW_PREFIX/lib/${dep#@rpath/}" "$gtk_dylib"
+    ;;
+esac
+codesign --force --sign - "$gtk_dylib"
+if ! gtk_has_accesskit "$gtk_dylib"; then
+    echo "error: rebuilt libgtk-4.1.dylib still lacks the AccessKit backend" >&2
+    exit 1
+fi
+
+cp -a "$gtk_stage"/lib/libgtk-4*.dylib "$STAGE/lib/"
+deploy_stage "$STAGE"
+gtk_has_accesskit "$GTK_LIB" || {
+    echo "error: $GTK_LIB lacks the AccessKit backend after deployment" >&2
+    exit 1
+}
+gtk_has_accesskit "$GTK_KEG/lib/libgtk-4.1.dylib" || {
+    echo "error: the gtk4 keg copy lacks the AccessKit backend after deployment" >&2
+    exit 1
+}
+
+mkdir -p "$CACHE_DIR"
+rm -rf "$STAGE_CACHE"
+cp -a "$STAGE" "$STAGE_CACHE"
+rm -rf "$WORK"
+echo "gtk4-accesskit: done"

--- a/scripts/macos/gtk4-accesskit.sh
+++ b/scripts/macos/gtk4-accesskit.sh
@@ -55,7 +55,11 @@ STAGE_CACHE="$CACHE_DIR/gtk4-$gtk_ver"
 
 deploy_stage() {
     local stage="$1" f base
-    rsync -a "$stage/" "$BREW_PREFIX/"
+    # No dir times or ownership: on Intel BREW_PREFIX is /usr/local,
+    # whose top directory is root-owned, and restoring its mtime makes
+    # rsync fail with utimensat EPERM (exit 23) even though every file
+    # lands fine.
+    rsync -a --omit-dir-times --no-owner --no-group "$stage/" "$BREW_PREFIX/"
     # Keep the keg copy identical: libadwaita and the gtk modules load
     # GTK through the keg's opt path, and a second, backend-less GTK
     # there would race ours for the one slot in the app bundle.
@@ -130,7 +134,7 @@ if ! pkg-config --exists "$ak_module"; then
         fi
     done
     rsync -a "$ak_stage/" "$STAGE/"
-    rsync -a "$ak_stage/" "$BREW_PREFIX/"
+    rsync -a --omit-dir-times --no-owner --no-group "$ak_stage/" "$BREW_PREFIX/"
     if ! pkg-config --exists "$ak_module"; then
         echo "error: $ak_module still not found after installing accesskit-c" >&2
         exit 1

--- a/scripts/macos/gtk4-accesskit.sh
+++ b/scripts/macos/gtk4-accesskit.sh
@@ -31,12 +31,12 @@ ACCESSKIT_C_GIT="https://github.com/AccessKit/accesskit-c"
 
 GTK_LIB="$BREW_PREFIX/lib/libgtk-4.1.dylib"
 
-# The backend is compiled in, so its witness is in the library: a
-# load command for libaccesskit in the normal (shared) case, or at
-# least the backend's name string if it was ever linked statically.
+# The witness is the load commands: a GTK with the backend links the
+# accesskit dylib. Never scan strings for this — a stock GTK contains
+# the literal help text "accesskit - Disabled during GTK build", so a
+# strings match proves nothing.
 gtk_has_accesskit() {
-    otool -L "$1" 2>/dev/null | grep -qi accesskit \
-        || strings "$1" 2>/dev/null | grep -qw accesskit
+    otool -L "$1" 2>/dev/null | grep -qi accesskit
 }
 
 if gtk_has_accesskit "$GTK_LIB"; then

--- a/scripts/windows/bundle.sh
+++ b/scripts/windows/bundle.sh
@@ -108,19 +108,21 @@ fi
 # AccessKit backend (a UI Automation bridge), which the stock MSYS2
 # gtk4 does not compile in. CI rebuilds gtk4 with the backend enabled
 # (scripts/windows/gtk4-accesskit.sh); refuse to ship a GTK that would
-# present an empty window to screen readers. REQUIRE_A11Y=0 skips the
-# check for local builds against a stock GTK.
+# present an empty window to screen readers. The witness is the import
+# of the accesskit DLL — never a strings scan, since a stock GTK
+# contains the literal help text "accesskit - Disabled during GTK
+# build". REQUIRE_A11Y=0 skips the check for local builds against a
+# stock GTK.
 if [ "${REQUIRE_A11Y:-1}" = "1" ]; then
-    if ! objdump -p "$BIN/libgtk-4-1.dll" | grep -qi accesskit \
-        && ! strings -a "$BIN/libgtk-4-1.dll" | grep -qw accesskit; then
+    accesskit_dll="$(objdump -p "$BIN/libgtk-4-1.dll" \
+        | awk 'tolower($0) ~ /dll name:.*accesskit/ { print $3; exit }')"
+    if [ -z "$accesskit_dll" ]; then
         echo "error: bundled GTK lacks the AccessKit accessibility backend;" >&2
         echo "       run scripts/windows/gtk4-accesskit.sh first, or set REQUIRE_A11Y=0" >&2
         echo "       to build a bundle that Windows screen readers cannot read" >&2
         exit 1
     fi
-    accesskit_dll="$(objdump -p "$BIN/libgtk-4-1.dll" \
-        | awk 'tolower($0) ~ /dll name:.*accesskit/ { print $3; exit }')"
-    if [ -n "$accesskit_dll" ] && [ ! -f "$BIN/$accesskit_dll" ]; then
+    if [ ! -f "$BIN/$accesskit_dll" ]; then
         echo "error: bundled GTK imports $accesskit_dll but the DLL closure did not ship it" >&2
         exit 1
     fi

--- a/scripts/windows/gtk4-accesskit.sh
+++ b/scripts/windows/gtk4-accesskit.sh
@@ -32,12 +32,12 @@ ACCESSKIT_C_GIT="https://github.com/AccessKit/accesskit-c"
 
 GTK_DLL="$PREFIX/bin/libgtk-4-1.dll"
 
-# The backend is compiled in, so its witness is in the DLL: an import
-# of libaccesskit.dll in the normal (shared) case, or at least the
-# backend's name string if it was ever linked statically.
+# The witness is the import table: a GTK with the backend links the
+# accesskit DLL. Never scan strings for this — a stock GTK contains
+# the literal help text "accesskit - Disabled during GTK build", so a
+# strings match proves nothing.
 gtk_has_accesskit() {
-    objdump -p "$GTK_DLL" 2>/dev/null | grep -qi accesskit \
-        || strings -a "$GTK_DLL" 2>/dev/null | grep -qw accesskit
+    objdump -p "$GTK_DLL" 2>/dev/null | awk '/DLL Name/' | grep -qi accesskit
 }
 
 if gtk_has_accesskit; then


### PR DESCRIPTION
## Summary

Follow-up to #65, which fixed the Windows zip for NVDA/JAWS. macOS has the same disease: Homebrew's gtk4 bottle is built without GTK's AccessKit backend (and Homebrew carries no accesskit-c formula at all), so the DMGs present an empty window to VoiceOver, which only reaches GTK through that backend's NSAccessibility bridge. Linux needs nothing — GTK always compiles its AT-SPI backend there, and the Flatpak/AppImage/deb packaging paths were audited and are fine (documented in `docs/accessibility.md`).

## Key changes

- **New script `scripts/macos/gtk4-accesskit.sh`**:
  - No-ops if the installed GTK already carries the backend (self-retires once Homebrew enables it upstream).
  - Builds accesskit-c from the upstream tarball — the exact version GTK's `meson.build` requires, discovered from the GTK source (`accesskit-c-0.18` for GTK 4.22).
  - Rebuilds the same GTK release Homebrew installed, from the upstream tarball, with the Homebrew formula's macOS meson arguments plus `-Daccesskit=enabled` (including the formula's `sassc` → `dart-sass` substitution and `G_DISABLE_ASSERT`/`G_DISABLE_CAST_CHECKS` flags; man pages and introspection are skipped since only the dylibs are taken).
  - Replaces `libgtk-4*.dylib` in **both** `$(brew --prefix)/lib` and the gtk4 keg: libadwaita and the gtk modules reference GTK through the keg's opt path, and a second backend-less copy there would race the accessible one for the single slot in the app bundle's Frameworks.
  - Normalizes install names to absolute Homebrew paths (and ad-hoc re-signs after `install_name_tool`) so the existing Mach-O closure in `bundle.sh` bundles `libaccesskit` like any other dependency.
  - Caches the built dylibs per gtk4 version so the rebuild runs once per gtk4 release and runner flavor.

- **`scripts/macos/bundle.sh`**: refuses to produce an app bundle whose `libgtk-4.1.dylib` lacks the AccessKit backend, and verifies the `libaccesskit` dylib landed in `Frameworks/`. `REQUIRE_A11Y=0` skips the gate for local builds against a stock GTK. This mirrors the Windows gate from #65, so an inaccessible build can never ship silently again on either platform.

- **`.github/workflows/ci.yml`**: all three macOS matrix jobs compute a cache key from the installed gtk4 version, restore/save the built dylibs via `actions/cache`, and run the rebuild before the app build.

- **Docs**: `docs/accessibility.md` gains the macOS bundle contract, a VoiceOver smoke test (Cmd+F5, then Tab / VO-arrows), and the Linux-packaging audit note; the README screen-reader bullet now covers macOS.

## Testing notes

Like #65, this could not be exercised on a macOS machine from this environment — the three `build-macos` CI jobs are the validation, and every step fails loudly rather than shipping a silently inaccessible bundle. The first run pays the GTK rebuild (~15–25 min per job); later runs restore it from cache. Real-world confirmation is a VoiceOver session against the resulting DMG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeKtchL1aPdUzN9CzwTAsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeKtchL1aPdUzN9CzwTAsN)_